### PR TITLE
Improvements on uncrustify.cfg

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -2772,7 +2772,7 @@ mod_add_long_function_closebrace_comment = 0        # unsigned number
 
 # If a namespace body exceeds the specified number of newlines and doesn't
 # have a comment after the close brace, a comment will be added.
-mod_add_long_namespace_closebrace_comment = 0        # unsigned number
+mod_add_long_namespace_closebrace_comment = 1        # unsigned number
 
 # If a class body exceeds the specified number of newlines and doesn't have a
 # comment after the close brace, a comment will be added.

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1829,11 +1829,11 @@ nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force
 
 # Whether to add a newline after '{'. This also adds a newline before the
 # matching '}'.
-nl_after_brace_open             = false    # true/false
+nl_after_brace_open             = true    # true/false
 
 # Whether to add a newline between the open brace and a trailing single-line
 # comment. Requires nl_after_brace_open=true.
-nl_after_brace_open_cmt         = false    # true/false
+nl_after_brace_open_cmt         = true    # true/false
 
 # Whether to add a newline after a virtual brace open with a non-empty body.
 # These occur in un-braced if/while/do/for statement bodies.
@@ -1845,7 +1845,7 @@ nl_after_vbrace_open_empty      = false    # true/false
 
 # Whether to add a newline after '}'. Does not apply if followed by a
 # necessary ';'.
-nl_after_brace_close            = false    # true/false
+nl_after_brace_close            = true    # true/false
 
 # Whether to add a newline after a virtual brace close,
 # as in 'if (foo) a++; <here> return;'.
@@ -2160,10 +2160,10 @@ nl_between_get_set              = 0        # unsigned number
 nl_property_brace               = ignore   # ignore/add/remove/force
 
 # Whether to remove blank lines after '{'.
-eat_blanks_after_open_brace     = false    # true/false
+eat_blanks_after_open_brace     = true    # true/false
 
 # Whether to remove blank lines before '}'.
-eat_blanks_before_close_brace   = false    # true/false
+eat_blanks_before_close_brace   = true    # true/false
 
 # How aggressively to remove extra newlines not in preprocessor.
 #

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -98,7 +98,7 @@ sp_cpp_lambda_assign            = remove   # ignore/add/remove/force
 
 # Add or remove space after the capture specification of a C++11 lambda when
 # an argument list is present, as in '[] <here> (int x){ ... }'.
-sp_cpp_lambda_square_paren      = add   # ignore/add/remove/force
+sp_cpp_lambda_square_paren      = remove   # ignore/add/remove/force
 
 # Add or remove space after the capture specification of a C++11 lambda with
 # no argument list is present, as in '[] <here> { ... }'.

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -2833,7 +2833,7 @@ mod_case_brace                  = ignore   # ignore/add/remove/force
 
 # Whether to remove a void 'return;' that appears as the last statement in a
 # function.
-mod_remove_empty_return         = false    # true/false
+mod_remove_empty_return         = true    # true/false
 
 # Add or remove the comma after the last value of an enumeration.
 mod_enum_last_comma             = ignore   # ignore/add/remove/force

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -66,6 +66,10 @@ utf8_byte                       = false    # true/false
 # Force the output encoding to UTF-8.
 utf8_force                      = false    # true/false
 
+#
+# Spacing options
+#
+
 # Add or remove space between 'do' and '{'.
 sp_do_brace_open                = ignore   # ignore/add/remove/force
 
@@ -73,11 +77,7 @@ sp_do_brace_open                = ignore   # ignore/add/remove/force
 sp_brace_close_while            = ignore   # ignore/add/remove/force
 
 # Add or remove space between 'while' and '('.
-sp_while_paren_open             = ignore   # ignore/add/remove/force
-
-#
-# Spacing options
-#
+sp_while_paren_open             = add   # ignore/add/remove/force
 
 # Add or remove space around non-assignment symbolic operators ('+', '/', '%',
 # '<<', and so forth).

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -94,11 +94,11 @@ sp_assign                       = add      # ignore/add/remove/force
 # Add or remove space around '=' in C++11 lambda capture specifications.
 #
 # Overrides sp_assign.
-sp_cpp_lambda_assign            = ignore   # ignore/add/remove/force
+sp_cpp_lambda_assign            = remove   # ignore/add/remove/force
 
 # Add or remove space after the capture specification of a C++11 lambda when
 # an argument list is present, as in '[] <here> (int x){ ... }'.
-sp_cpp_lambda_square_paren      = ignore   # ignore/add/remove/force
+sp_cpp_lambda_square_paren      = add   # ignore/add/remove/force
 
 # Add or remove space after the capture specification of a C++11 lambda with
 # no argument list is present, as in '[] <here> { ... }'.
@@ -1300,7 +1300,7 @@ indent_vbrace_open_on_tabstop   = false    # true/false
 indent_token_after_brace        = true     # true/false
 
 # Whether to indent the body of a C++11 lambda.
-indent_cpp_lambda_body          = false    # true/false
+indent_cpp_lambda_body          = true    # true/false
 
 # How to indent compound literals that are being returned.
 # true: add both the indent from return & the compound literal open brace (ie:
@@ -1803,7 +1803,7 @@ nl_fdef_brace                   = add      # ignore/add/remove/force
 nl_fdef_brace_cond              = ignore   # ignore/add/remove/force
 
 # Add or remove newline between C++11 lambda signature and '{'.
-nl_cpp_ldef_brace               = ignore   # ignore/add/remove/force
+nl_cpp_ldef_brace               = add   # ignore/add/remove/force
 
 # Add or remove newline between 'return' and the return expression.
 nl_return_expr                  = ignore   # ignore/add/remove/force

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -2784,7 +2784,7 @@ mod_add_long_switch_closebrace_comment = 0        # unsigned number
 
 # If an #ifdef body exceeds the specified number of newlines and doesn't have
 # a comment after the #endif, a comment will be added.
-mod_add_long_ifdef_endif_comment = 0        # unsigned number
+mod_add_long_ifdef_endif_comment = 1        # unsigned number
 
 # If an #ifdef or #else body exceeds the specified number of newlines and
 # doesn't have a comment after the #else, a comment will be added.


### PR DESCRIPTION
* Indentation of lambdas
* Force space on `while <here> (`
* Fixing newlines and braces
* Remove `return;` from end of function
* Force comment with name of namespace at closing brace
* Force comment with name of define at `#endif` of `#ifdef`